### PR TITLE
Stop adding AttributesToAvoidReplicating

### DIFF
--- a/src/FakeItEasy/Creation/CastleDynamicProxy/CastleDynamicProxyGenerator.cs
+++ b/src/FakeItEasy/Creation/CastleDynamicProxy/CastleDynamicProxyGenerator.cs
@@ -7,11 +7,7 @@ namespace FakeItEasy.Creation.CastleDynamicProxy
     using System.Linq;
     using System.Reflection;
     using System.Reflection.Emit;
-#if FEATURE_SECURITY_PERMISSIONS
-    using System.Security.Permissions;
-#endif
     using Castle.DynamicProxy;
-    using Castle.DynamicProxy.Generators;
     using FakeItEasy.Core;
 
     internal class CastleDynamicProxyGenerator
@@ -20,16 +16,6 @@ namespace FakeItEasy.Creation.CastleDynamicProxy
         private static readonly IProxyGenerationHook ProxyGenerationHook = new InterceptEverythingHook();
         private static readonly ProxyGenerator ProxyGenerator = new ProxyGenerator();
         private readonly CastleDynamicProxyInterceptionValidator interceptionValidator;
-
-#if FEATURE_SECURITY_PERMISSIONS
-        [SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline", Justification = "No field initialization.")]
-        static CastleDynamicProxyGenerator()
-        {
-#pragma warning disable 618
-            AttributesToAvoidReplicating.Add(typeof(SecurityPermissionAttribute));
-#pragma warning restore 618
-        }
-#endif
 
         public CastleDynamicProxyGenerator(CastleDynamicProxyInterceptionValidator interceptionValidator)
         {

--- a/src/FakeItEasy/FakeItEasy.csproj
+++ b/src/FakeItEasy/FakeItEasy.csproj
@@ -30,7 +30,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;FEATURE_BINARY_SERIALIZATION FEATURE_SECURITY_PERMISSIONS FEATURE_REFLECTION_GETASSEMBLIES FEATURE_SELF_INITIALIZED_FAKES</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FEATURE_BINARY_SERIALIZATION FEATURE_REFLECTION_GETASSEMBLIES FEATURE_SELF_INITIALIZED_FAKES</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>..\..\FakeItEasy.ruleset</CodeAnalysisRuleSet>
@@ -41,7 +41,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;FEATURE_BINARY_SERIALIZATION FEATURE_SECURITY_PERMISSIONS FEATURE_REFLECTION_GETASSEMBLIES FEATURE_SELF_INITIALIZED_FAKES</DefineConstants>
+    <DefineConstants>TRACE;FEATURE_BINARY_SERIALIZATION FEATURE_REFLECTION_GETASSEMBLIES FEATURE_SELF_INITIALIZED_FAKES</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>Bin\Release\FakeItEasy.xml</DocumentationFile>


### PR DESCRIPTION
The SecurityPermissionAttribute has been
automatically excluded from replication since
Castle.Core 2.5.2.
