### PR TITLE
Restore excluded integration test

### DIFF
--- a/tests/FakeItEasy.IntegrationTests/FakeItEasy.IntegrationTests.csproj
+++ b/tests/FakeItEasy.IntegrationTests/FakeItEasy.IntegrationTests.csproj
@@ -28,7 +28,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FEATURE_BINARY_SERIALIZATION</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>..\FakeItEasy.Tests.ruleset</CodeAnalysisRuleSet>
@@ -42,7 +42,7 @@
     <DebugSymbols>true</DebugSymbols>
     <Optimize>true</Optimize>
     <OutputPath>Bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;FEATURE_BINARY_SERIALIZATION</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>..\FakeItEasy.Tests.ruleset</CodeAnalysisRuleSet>


### PR DESCRIPTION
We'd accidentally lost `Should_be_able_to_use_a_fake_after_binary_deserializing_it` because `FEATURE_BINARY_SERIALIZATION` was not defined in the integration test project.
